### PR TITLE
fix: update lodash import for esm builds

### DIFF
--- a/src/utils/walletconnect/WalletConnectWallet.ts
+++ b/src/utils/walletconnect/WalletConnectWallet.ts
@@ -5,7 +5,7 @@ import { buildApprovedNamespaces, getSdkError } from "@walletconnect/utils"
 import { Web3Wallet } from "@walletconnect/web3wallet"
 import type Web3WalletType from "@walletconnect/web3wallet"
 import type { Web3WalletTypes } from "@walletconnect/web3wallet"
-import uniq from "lodash/uniq"
+import uniq from "lodash/uniq.js"
 import {
     EIP155,
     KERNEL_COMPATIBLE_EVENTS,


### PR DESCRIPTION
Allows package to be built, previously would receive. 
```
waas % node dist/esm/index.js

node:internal/process/esm_loader:34
      internalBinding('errors').triggerUncaughtException(
                                ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/waas/node_modules/lodash/uniq' imported from //waas/dist/esm/index.js
Did you mean to import "lodash/uniq.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:263:11)
    at moduleResolve (node:internal/modules/esm/resolve:908:10)
    at defaultResolve (node:internal/modules/esm/resolve:1131:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:390:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:359:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:234:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: '/waas/node_modules/lodash/uniq'
}

Node.js v21.6.2
