### PR TITLE
fix: align viem with version used in core

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
         "@tanstack/react-query": "^5.28.14",
         "react": ">=18.2.0",
         "typescript": ">=5.4.3",
-        "viem": "2.9.16",
+        "viem": "2.9.17",
         "wagmi": ">=2.5.0"
     },
     "resolutions": {
-        "viem": "2.9.16"
+        "viem": "2.9.17"
     },
     "exports": {
         ".": {


### PR DESCRIPTION
Allows packages to install, previously received

```
waas % npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @zerodev/waas@0.2.2-alpha.0
npm ERR! Found: viem@2.9.16
npm ERR! node_modules/viem
npm ERR!   peer viem@"2.9.16" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer viem@"^2.9.17" from permissionless@0.1.30
npm ERR! node_modules/permissionless
npm ERR!   peer permissionless@"^0.1.18" from @zerodev/ecdsa-validator@5.2.3
npm ERR!   node_modules/@zerodev/ecdsa-validator
npm ERR!     @zerodev/ecdsa-validator@"5.2.3" from the root project
npm ERR!   peer permissionless@"^0.1.18" from @zerodev/sdk@5.2.10
npm ERR!   node_modules/@zerodev/sdk
npm ERR!     @zerodev/sdk@"5.2.10" from the root project
npm ERR!     1 more (@zerodev/ecdsa-validator)
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! .npm/_logs/2024-06-07T23_49_52_827Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /.npm/_logs/2024-06-07T23_49_52_827Z-debug-0.log
```
Updated to align with core sdks peer deps however the core sdk uses ```^2.13.7``` as does permissionless, I will let you make the decision if this package should as well to stay aligned.


For time being developers can use 

```
"overrides": {
    "@zerodev/waas": {
      "viem": "^2.13.7"
    }
  },
 ```
 in their package.json
