### PR TITLE
fix: biome apply+comma depricated

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,7 @@
     "javascript": {
         "formatter": {
             "semicolons": "asNeeded",
-            "trailingComma": "none"
+            "trailingCommas": "none"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "dev": "tsup --watch",
         "format": "biome format . --write",
         "lint": "biome check .",
-        "lint:fix": "bun run lint --apply"
+        "lint:fix": "bun run lint --write"
     },
     "keywords": [],
     "author": "ZeroDev",


### PR DESCRIPTION
```trailingComma``` has been moved to ```trailingCommas```. As well as ``` The argument --apply is deprecated, it will be removed in the next major release. Use --write instead.```